### PR TITLE
Missing Include for 5.4.2

### DIFF
--- a/Source/SUSS/Public/SussSettings.h
+++ b/Source/SUSS/Public/SussSettings.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "SussAction.h"
 #include "SussInputProvider.h"
 #include "SussParameterProvider.h"
 #include "SussQueryProvider.h"


### PR DESCRIPTION
Attempted to compile in rider, `USussAction` was not defined. Adding the include fixed the compilation error.