### PR TITLE
Check for nullptr is RunEQSQuery return value

### DIFF
--- a/Source/SUSS/Private/Queries/SussEQSQueryProvider.cpp
+++ b/Source/SUSS/Private/Queries/SussEQSQueryProvider.cpp
@@ -52,7 +52,7 @@ void USussEQSTargetQueryProvider::ExecuteQuery(USussBrainComponent* Brain,
                                                TArray<TWeakObjectPtr<AActor>>& OutResults)
 {
 	const auto Result = RunEQSQuery(Brain, Self, Params, Context);
-	if (Result->ItemType->IsChildOf(UEnvQueryItemType_ActorBase::StaticClass()))
+	if (Result && Result->ItemType->IsChildOf(UEnvQueryItemType_ActorBase::StaticClass()))
 	{
 		const UEnvQueryItemType_ActorBase* DefTypeOb =  Result->ItemType->GetDefaultObject<UEnvQueryItemType_ActorBase>();
 
@@ -84,7 +84,7 @@ void USussEQSLocationQueryProvider::ExecuteQuery(USussBrainComponent* Brain,
                                                  TArray<FVector>& OutResults)
 {
 	const auto Result = RunEQSQuery(Brain, Self, Params, Context);
-	if (Result->ItemType->IsChildOf(UEnvQueryItemType_VectorBase::StaticClass()))
+	if (Result && Result->ItemType->IsChildOf(UEnvQueryItemType_VectorBase::StaticClass()))
 	{
 		const UEnvQueryItemType_VectorBase* DefTypeOb =  Result->ItemType->GetDefaultObject<UEnvQueryItemType_VectorBase>();
 		if (QueryMode == EEnvQueryRunMode::AllMatching)


### PR DESCRIPTION
Minor tweaks, feel free to ignore. I think this happens when the system isn't correctly configured but it should probably be checked for.

In [SUSSUtility.cpp:201](https://github.com/sinbad/SUSS/blob/master/Source/SUSS/Private/SussUtility.cpp#L201):

    auto Ret = RunEQSQuery(Querier, EQSQuery, QueryParams, QueryMode);

it looks like Ret isn't used for anything? Are there side effects to calling RunEQSQuery that I don't understand or is this an error?