### PR TITLE
Adjust ExecuteQueryBP to function where possible

### DIFF
--- a/Source/SUSS/Private/SussQueryProvider.cpp
+++ b/Source/SUSS/Private/SussQueryProvider.cpp
@@ -47,9 +47,8 @@ void USussTargetQueryProvider::ExecuteQuery(USussBrainComponent* Brain,
                                             const FSussContext& Context,
                                             TArray<TWeakObjectPtr<AActor>>& OutResults)
 {
-	// Subclasses can override; this one needs to proxy to BP-compatible (non-weak pointer) version
-	TArray<AActor*> BPArray;
-	ExecuteQueryBP(Brain, Self, Params, Context, BPArray);
+	// Subclasses can override this, call BP version by default
+	const TArray<AActor*> BPArray = ExecuteQueryBP(Brain, Self, Params, Context);
 	OutResults.Append(BPArray);
 }
 
@@ -60,7 +59,8 @@ void USussLocationQueryProvider::ExecuteQuery(USussBrainComponent* Brain,
                                               TArray<FVector>& OutResults)
 {
 	// Subclasses can override this, call BP version by default
-	ExecuteQueryBP(Brain, Self, Params, Context, OutResults);
+	const TArray<FVector> BPArray = ExecuteQueryBP(Brain, Self, Params, Context);
+	OutResults.Append(BPArray);
 }
 
 void USussNamedValueQueryProvider::AddValueStruct(const TSharedPtr<const FSussContextValueStructBase>& Struct)

--- a/Source/SUSS/Public/SussQueryProvider.h
+++ b/Source/SUSS/Public/SussQueryProvider.h
@@ -302,11 +302,10 @@ protected:
 	 * @param OutResults Array that new query results should be appended to
 	 */
 	UFUNCTION(BlueprintImplementableEvent, DisplayName="ExecuteQuery")
-	void ExecuteQueryBP(USussBrainComponent* Brain,
+	TArray<AActor*> ExecuteQueryBP(USussBrainComponent* Brain,
 	                    AActor* ControlledActor,
 	                    const TMap<FName, FSussParameter>& Params,
-	                    const FSussContext& BaseContext,
-	                    UPARAM(ref) TArray<AActor*>& OutResults);
+	                    const FSussContext& BaseContext);
 
 	virtual void ExecuteQueryInternal(USussBrainComponent* Brain, AActor* Self, const TMap<FName, FSussParameter>& Params, TSussResultsArray& OutResults) override final
 	{
@@ -363,12 +362,10 @@ protected:
 	 * @param OutResults Array that new query results should be appended to
 	 */
 	UFUNCTION(BlueprintImplementableEvent, DisplayName="ExecuteQuery")
-	void ExecuteQueryBP(USussBrainComponent* Brain,
+	TArray<FVector> ExecuteQueryBP(USussBrainComponent* Brain,
 	                    AActor* ControlledActor,
 	                    const TMap<FName, FSussParameter>& Params,
-	                    const FSussContext& BaseContext,
-	                    UPARAM(ref) TArray<FVector>& OutResults);
-	
+	                    const FSussContext& BaseContext);
 
 	virtual void ExecuteQueryInternal(USussBrainComponent* Brain, AActor* Self, const TMap<FName, FSussParameter>& Params, TSussResultsArray& OutResults) override final
 	{


### PR DESCRIPTION
I created a Blueprint Query and ran into this "warning". My Blueprint Query was not returning any results. 
![ExecuteQueryAsEvent](https://github.com/user-attachments/assets/a519e443-7221-48f0-936d-dfa5b9fd6640)

I attempted to get around it by wrapping the results in a struct, and that didn't work either. I eventually found out the solution was to convert the BlueprintEvent to a Function

![ExecuteQueryAsFunction](https://github.com/user-attachments/assets/190ea32c-47bd-45e6-9b3f-23dea75a9d12)

This proposed change alters the ExecuteQueryBP to be functions that return their results, automatically making them "functions" in the blueprint sense and side stepping this reference and event lifetime struggle.

![ProposedChanges](https://github.com/user-attachments/assets/ff1c134d-6f4a-4909-8ef8-d6506a30c1e3)

This alters the c++ code slightly, and does create an extra allocation in the location variation of the function, but as that was already happening for the actor variation, I think the change is worth the clarification on the blueprint side.

Let me know what you think!

edit: also I intend to be using this library quite a bit, hopefully mostly through blueprints. Let me know if there's anything I can do to make these PR's more helpful, clear or mergable.
