### PR TITLE
Update the deprecated usage of EAutomationTestFlags::ApplicationContextMask

### DIFF
--- a/Source/SUSS/Private/Tests/SussTestBrainComponent.spec.cpp
+++ b/Source/SUSS/Private/Tests/SussTestBrainComponent.spec.cpp
@@ -7,9 +7,15 @@
 UE_DISABLE_OPTIMIZATION
 
 
+#if ENGINE_MAJOR_VERSION==5&&ENGINE_MINOR_VERSION>=5
+BEGIN_DEFINE_SPEC(FSussBrainTestContextsSpec,
+				  "SUSS: Test  Contexts",
+				  EAutomationTestFlags_ApplicationContextMask | EAutomationTestFlags::ProductFilter);
+#else
 BEGIN_DEFINE_SPEC(FSussBrainTestContextsSpec,
 				  "SUSS: Test  Contexts",
 				  EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::ProductFilter);
+#endif
 
 	TUniquePtr<FSussTestWorldFixture> WorldFixture;
 


### PR DESCRIPTION
In version 5.5, they removed EAutomationTestFlags::ApplicationContextMask.
Relevant engine commits:
https://github.com/EpicGames/UnrealEngine/commit/85f2d450ad559a0d0164cdd82d33b10d73f03749
https://github.com/EpicGames/UnrealEngine/commit/fe3efb84feb1822ff0ad036c9e98dc02b3fae918

I made compatibility updates for it, fixing the plugin's compilation errors under 5.5.